### PR TITLE
allow defense_finder to run on files containing spaces

### DIFF
--- a/defense_finder/__init__.py
+++ b/defense_finder/__init__.py
@@ -1,29 +1,13 @@
 import subprocess
 
 def run(f, dbtype, workers, tmp_dir):
-    script = """
-macsyfinder --db-type {dbtype} --sequence-db {file} --models defense-finder-models/DefenseFinder_1 all --out-dir {dir}/DF_1 --coverage-profile 0.1  --w {workers} --exchangeable-weight 1
-macsyfinder --db-type {dbtype} --sequence-db {file} --models defense-finder-models/DefenseFinder_2 all --out-dir {dir}/DF_2 --coverage-profile 0.1  --w {workers} --exchangeable-weight 1
-macsyfinder --db-type {dbtype} --sequence-db {file} --models defense-finder-models/DefenseFinder_3 all --out-dir {dir}/DF_3 --coverage-profile 0.1  --w {workers} --exchangeable-weight 1
-macsyfinder --db-type {dbtype} --sequence-db {file} --models defense-finder-models/DefenseFinder_4 all --out-dir {dir}/DF_4 --coverage-profile 0.1  --w {workers} --exchangeable-weight 1
-macsyfinder --db-type {dbtype} --sequence-db {file} --models defense-finder-models/DefenseFinder_5 all --out-dir {dir}/DF_5 --coverage-profile 0.1  --w {workers} --exchangeable-weight 1
-macsyfinder --db-type {dbtype} --sequence-db {file} --models defense-finder-models/RM all --out-dir {dir}/RM --coverage-profile 0.1  --w {workers} --exchangeable-weight 1
-macsyfinder --db-type {dbtype} --sequence-db {file} --models defense-finder-models/Cas all --out-dir {dir}/Cas --accessory-weight 1 --exchangeable-weight 1 --coverage-profile 0.4 -w {workers}
-""".format(workers=workers, file=escapeFileName(f.name), dbtype=dbtype, dir=tmp_dir)
-
+    script = f"""
+macsyfinder --db-type {dbtype} --sequence-db "{f.name}" --models defense-finder-models/DefenseFinder_1 all --out-dir {tmp_dir}/DF_1 --coverage-profile 0.1  --w {workers} --exchangeable-weight 1
+macsyfinder --db-type {dbtype} --sequence-db "{f.name}" --models defense-finder-models/DefenseFinder_2 all --out-dir {tmp_dir}/DF_2 --coverage-profile 0.1  --w {workers} --exchangeable-weight 1
+macsyfinder --db-type {dbtype} --sequence-db "{f.name}" --models defense-finder-models/DefenseFinder_3 all --out-dir {tmp_dir}/DF_3 --coverage-profile 0.1  --w {workers} --exchangeable-weight 1
+macsyfinder --db-type {dbtype} --sequence-db "{f.name}" --models defense-finder-models/DefenseFinder_4 all --out-dir {tmp_dir}/DF_4 --coverage-profile 0.1  --w {workers} --exchangeable-weight 1
+macsyfinder --db-type {dbtype} --sequence-db "{f.name}" --models defense-finder-models/DefenseFinder_5 all --out-dir {tmp_dir}/DF_5 --coverage-profile 0.1  --w {workers} --exchangeable-weight 1
+macsyfinder --db-type {dbtype} --sequence-db "{f.name}" --models defense-finder-models/RM all --out-dir {tmp_dir}/RM --coverage-profile 0.1  --w {workers} --exchangeable-weight 1
+macsyfinder --db-type {dbtype} --sequence-db "{f.name}" --models defense-finder-models/Cas all --out-dir {tmp_dir}/Cas --accessory-weight 1 --exchangeable-weight 1 --coverage-profile 0.4 -w {workers}
+"""
     subprocess.run(script, shell=True)
-
-def escapeFileName(f):
-    r = ""
-    for char in f:
-        if char >= "a" and char <= "z":
-            r += char
-        elif char >= "A" and char <= "Z":
-            r += char
-        elif char >= "0" and char <= "9":
-            r += char
-        elif char in ["-", "_", ".", "/"]:
-            r += char
-        else:
-            r += "\\" + char
-    return r

--- a/defense_finder/__init__.py
+++ b/defense_finder/__init__.py
@@ -9,6 +9,21 @@ macsyfinder --db-type {dbtype} --sequence-db {file} --models defense-finder-mode
 macsyfinder --db-type {dbtype} --sequence-db {file} --models defense-finder-models/DefenseFinder_5 all --out-dir {dir}/DF_5 --coverage-profile 0.1  --w {workers} --exchangeable-weight 1
 macsyfinder --db-type {dbtype} --sequence-db {file} --models defense-finder-models/RM all --out-dir {dir}/RM --coverage-profile 0.1  --w {workers} --exchangeable-weight 1
 macsyfinder --db-type {dbtype} --sequence-db {file} --models defense-finder-models/Cas all --out-dir {dir}/Cas --accessory-weight 1 --exchangeable-weight 1 --coverage-profile 0.4 -w {workers}
-""".format(workers=workers, file=f.name, dbtype=dbtype, dir=tmp_dir)
+""".format(workers=workers, file=escapeFileName(f.name), dbtype=dbtype, dir=tmp_dir)
 
     subprocess.run(script, shell=True)
+
+def escapeFileName(f):
+    r = ""
+    for char in f:
+        if char >= "a" and char <= "z":
+            r += char
+        elif char >= "A" and char <= "Z":
+            r += char
+        elif char >= "0" and char <= "9":
+            r += char
+        elif char in ["-", "_", ".", "/"]:
+            r += char
+        else:
+            r += "\\" + char
+    return r

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read_md(f):
     return text
 
 setup(name='mdmparis-defense-finder',
-        version='1.0.2',
+        version='1.0.3',
         description="Defense Finder: allow for a systematic search of all known anti-phage systems.",
         long_description=read_md('README.md'),
         long_description_content_type="text/markdown",


### PR DESCRIPTION
This solves a bug that would occur when the given filename contains special characters (such as spaces)