### PR TITLE
allow to force reinstall models

### DIFF
--- a/defense_finder_cli/main.py
+++ b/defense_finder_cli/main.py
@@ -34,7 +34,9 @@ def cli():
 
 @cli.command()
 @click.option('--models-dir', 'models_dir', required=False, help='Specify a directory containing your models.')
-def update(models_dir=None):
+@click.option('--force-reinstall', '-f', 'force_reinstall', is_flag=True,
+              help='Force update even if models in already there.', default=False)
+def update(models_dir=None, force_reinstall: bool = False):
     """Fetches the latest defense finder models.
 
     The models will be downloaded from mdmparis repositories and installed on macsydata.
@@ -43,7 +45,7 @@ def update(models_dir=None):
 
     Models repository: https://github.com/mdmparis/defense-finder-models.
     """
-    defense_finder_updater.update_models(models_dir)
+    defense_finder_updater.update_models(models_dir, force_reinstall)
 
 
 @cli.command()

--- a/defense_finder_updater/__init__.py
+++ b/defense_finder_updater/__init__.py
@@ -1,14 +1,16 @@
 import shlex
 from macsypy.scripts import macsydata
 
-def update_models(models_dir):
+
+def update_models(models_dir, force_reinstall: bool):
     # Updating DefenseFinder models
     args_models_dir = f"-t {models_dir}" if models_dir is not None else "-u"
-    cmd_args = f"install -U {args_models_dir} --org mdmparis defense-finder-models"
+    args_force = "-f" if force_reinstall else ""
+    cmd_args = f"install -U {args_models_dir} {args_force} --org mdmparis defense-finder-models"
     macsydata.main(shlex.split(cmd_args))
 
     # Updating CASFinder models
     args_models_dir = f"-t {models_dir}" if models_dir is not None else "-u"
-    cmd_args = f"install -U {args_models_dir} CasFinder"
+    cmd_args = f"install -U {args_models_dir} {args_force} CasFinder"
     macsydata.main(shlex.split(cmd_args))
 


### PR DESCRIPTION
Add option `--force-reinstall` that is suggested by underlying macsydata, but was not usable directly with defense-finder