### PR TITLE
Allow to specify a path to an index dir for msf

### DIFF
--- a/defense_finder/__init__.py
+++ b/defense_finder/__init__.py
@@ -4,7 +4,7 @@ import colorlog
 from macsypy.scripts import macsyfinder
 
 
-def run(protein_file_name, dbtype, workers, coverage, tmp_dir, models_dir, nocut_ga, loglevel):
+def run(protein_file_name, dbtype, workers, coverage, tmp_dir, models_dir, nocut_ga, loglevel, index_dir):
 
     gen_args = ['--db-type', dbtype, '--sequence-db', protein_file_name, '--models', 'defense-finder-models/DefenseFinder_{i}', 'all',
                 '--out-dir', os.path.join(tmp_dir, 'DF_{i}'), '--w', str(workers),
@@ -23,6 +23,8 @@ def run(protein_file_name, dbtype, workers, coverage, tmp_dir, models_dir, nocut
             msf_cmd.append("--no-cut-ga")
         if models_dir:
             msf_cmd.extend(("--models-dir", models_dir))
+        if index_dir:
+            msf_cmd.extend(("--index-dir", index_dir))
         if loglevel != "DEBUG":
             msf_cmd.append("--mute")
 

--- a/defense_finder_cli/main.py
+++ b/defense_finder_cli/main.py
@@ -72,7 +72,7 @@ def update(models_dir=None, force_reinstall: bool = False):
 
 def run(file: str, outdir: str, dbtype: str, workers: int, coverage: float, preserve_raw: bool, 
         no_cut_ga: bool, models_dir: str = None, loglevel : str = "INFO",
-        models_dir: str = None):
+        index_dir: str = None):
     """
     Search for all known anti-phage defense systems in the target fasta file.
     """

--- a/defense_finder_cli/main.py
+++ b/defense_finder_cli/main.py
@@ -67,9 +67,12 @@ def update(models_dir=None, force_reinstall: bool = False):
               help='Advanced! Run macsyfinder in no-cut-ga mode. The validity of the genes and systems found is not guaranteed!')
 @click.option('--log-level', 'loglevel', default="INFO",
               help='set the logging level among DEBUG, [INFO], WARNING, ERROR, CRITICAL')
+@click.option('--index-dir', 'index_dir', required=False, help='Specify a directory to write the index files required by macsyfinder when the input file is in a read-only folder')
 
 
-def run(file: str, outdir: str, dbtype: str, workers: int, coverage: float, preserve_raw: bool, no_cut_ga: bool, models_dir: str = None, loglevel : str = "INFO"):
+def run(file: str, outdir: str, dbtype: str, workers: int, coverage: float, preserve_raw: bool, 
+        no_cut_ga: bool, models_dir: str = None, loglevel : str = "INFO",
+        models_dir: str = None):
     """
     Search for all known anti-phage defense systems in the target fasta file.
     """
@@ -144,7 +147,7 @@ def run(file: str, outdir: str, dbtype: str, workers: int, coverage: float, pres
             protein_file_name = filename
 
     logger.info("Running DefenseFinder")
-    defense_finder.run(protein_file_name, dbtype, workers, coverage, tmp_dir, models_dir, no_cut_ga, loglevel)
+    defense_finder.run(protein_file_name, dbtype, workers, coverage, tmp_dir, models_dir, no_cut_ga, loglevel, index_dir)
     logger.info("Post-treatment of the data")
     defense_finder_posttreat.run(tmp_dir, outdir, os.path.splitext(os.path.basename(filename))[0])
 


### PR DESCRIPTION
When running defenseFinder on a file present in readonly folder, the idx cannot be created and thus everything crashes.