### PR TITLE
Fix command for creating Conda environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ DefenseFinder is installable through pip.
 Before starting, if you can, it is recommended to install DefenseFinder in a virtualenv (such as condas).
 
 ```sh
-conda create --name defensefinder
+conda create --name defensefinder python=3.9 pip
 conda activate defensefinder
 pip install mdmparis-defense-finder
 ```

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ DefenseFinder is installable through pip.
 Before starting, if you can, it is recommended to install DefenseFinder in a virtualenv (such as condas).
 
 ```sh
-conda create –name defensefinder
+conda create --name defensefinder
 conda activate defensefinder
 pip install mdmparis-defense-finder
 ```


### PR DESCRIPTION
Hi, thank you for this interesting work! 

I fixed the command for creating a Conda environment. 
There was a slight typo in the `-name` flag (which should be `--name`).

I also added the installation of Python and pip to further streamline the installation of DefenseFinder via Conda.