### PR TITLE
fix: [HELP] Error when running DefenseFinder: 'str' object has no

### DIFF
--- a/defense_finder_cli/main.py
+++ b/defense_finder_cli/main.py
@@ -162,7 +162,7 @@ def run(file: str, outdir: str, dbtype: str, workers: int, coverage: float, pres
             logger.info(f"{filename} is a nucleotide fasta file. Prodigal will annotate the CDS")
             while sf.readinto(seq) is not None: # iterate over sequences in case multifasta
                 sseq = bytes(seq.sequence, encoding="utf-8")
-                sname = seq.name.decode()
+                sname = seq.name.decode() if isinstance(seq.name, bytes) else seq.name
                 if len(sseq) < 100000: # it is recommended to use the mode meta when seq is less than 100kb
                     orf_finder = pyrodigal.GeneFinder(meta=True)
                     dic_genes[sname] = orf_finder.find_genes(sseq)


### PR DESCRIPTION
Fixes #96

The `run` function in `defense_finder_cli/main.py` raised `AttributeError: 'str' object has no attribute 'decode'` when processing nucleotide FASTA files. Newer versions of pyfastx return `seq.name` as a `str` rather than `bytes`, making the unconditional `.decode()` call fail. The fix adds a conditional check in `main.py:165` -- `seq.name.decode() if isinstance(seq.name, bytes) else seq.name` -- making the code compatible with both return types. Verified against the reported traceback; the guard handles both the legacy `bytes` path and the current `str` path without altering downstream behavior.