### PR TITLE
Filters duplicates in systems results

### DIFF
--- a/defense_finder_posttreat/df_systems.py
+++ b/defense_finder_posttreat/df_systems.py
@@ -20,8 +20,9 @@ def build_defense_finder_systems(defense_finder_genes):
         name_of_profiles_in_sys = defense_finder_genes.groupby('sys_id').gene_name.apply(lambda x: ",".join(x.sort_values())).reset_index().rename({'gene_name': 'name_of_profiles_in_sys'}, axis=1)
         out = out.merge(name_of_profiles_in_sys, on='sys_id')
         # Reorder by hit_pos
-        out = out.merge(defense_finder_genes[['hit_id', 'hit_pos']], left_on='sys_beg', right_on='hit_id').sort_values('hit_pos').reset_index(drop=True)
+        out = out.merge(defense_finder_genes[['hit_id', 'hit_pos']], left_on='sys_beg', right_on='hit_id').sort_values('hit_pos')
         out = out.drop(columns=['hit_id', 'hit_pos'])
+        out = out.drop_duplicates().reset_index(drop=True)
     else:
         out = pd.DataFrame(columns=['sys_id', 'type', 'subtype', 'activity', 'sys_beg', 'sys_end', 'protein_in_syst', 'genes_count', 'name_of_profiles_in_sys'])
 


### PR DESCRIPTION
Hello, 
Regarding an issue that I posted [#130](https://github.com/mdmparis/defense-finder/issues/104), I tested a branch with a small fix that corrects the issue. 

**Before the fix**: 
On genome [GCF_000154345.1](https://www.ncbi.nlm.nih.gov/datasets/genome/GCF_000154345.1/) using its GEMBase database (created internally) as the input file, some results appear duplicated in the _systems.tsv file. 
```
10075S4_RM_Type_II_5	RM	RM_Type_II	Defense	10075S4_45252747	10075S4_45252748	10075S4_45252747,10075S4_45252748	2	RM_Type_II__Type_II_MTases_FAM_35,RM_Type_II__Type_II_REase34
10075S4_RM_Type_II_5	RM	RM_Type_II	Defense	10075S4_45252747	10075S4_45252748	10075S4_45252747,10075S4_45252748	2	RM_Type_II__Type_II_MTases_FAM_35,RM_Type_II__Type_II_REase34
10075S4_dam_8	Anti_RM	dam	Antidefense	10075S4_45252747	10075S4_45252747	10075S4_45252747	1	dam
10075S4_dam_8	Anti_RM	dam	Antidefense	10075S4_45252747	10075S4_45252747	10075S4_45252747	1	dam
```

**After the fix**: 
The duplicated results are cleaned out
```
10075S4_RM_Type_II_7	RM	RM_Type_II	Defense	10075S4_45252747	10075S4_45252748	10075S4_45252747,10075S4_45252748	2	RM_Type_II__Type_II_MTases_FAM_35,RM_Type_II__Type_II_REase34
10075S4_dam_8	Anti_RM	dam	Antidefense	10075S4_45252747	10075S4_45252747	10075S4_45252747	1	dam
```

Finding duplicates was not an isolated case, so I also checked that the correction worked on other genomes.

I hope its useful. 